### PR TITLE
Fix deleting article comments

### DIFF
--- a/src/machines/article.machine.ts
+++ b/src/machines/article.machine.ts
@@ -276,7 +276,7 @@ export const articleMachine = createMachine<
               del(`articles/${context.slug}/comments/${event.id}`)
             ),
             comments:
-              context.comments?.filter(comment => comment.id === event.id) || []
+              context.comments?.filter(comment => comment.id !== event.id) || []
           };
         }
         return context;


### PR DESCRIPTION
There is a bug on the Article page. After a comment is deleted, the list of comments displays the deleted comment and no other. This is the fix.